### PR TITLE
delineate requirements from conformance class

### DIFF
--- a/standard/abstract_tests/ATS_class_core.adoc
+++ b/standard/abstract_tests/ATS_class_core.adoc
@@ -1,7 +1,7 @@
 [[ats_core]]
 ====
 [%metadata]
-label:: http://wis.wmo.int/spec/wth/1/conf/core
+label:: http://wis.wmo.int/spec/wth/1/req/core
 subject:: Requirements Class "core"
 classification:: Target Type:Topic Classification
 ====

--- a/standard/sections/clause_2_conformance.adoc
+++ b/standard/sections/clause_2_conformance.adoc
@@ -7,8 +7,8 @@ of providing MQP services in alignment with the defined topic structure.
 
 WMO shall publish guidance material to assist WIS Global Brokers and Nodes in constructing valid topic structures.
 
-This standard identifies one Conformance Class which defines the functional requirements.
+This standard identifies one Requirements Class which defines the functional requirements.
 
-The mandatory Conformance Class for this specification is:
+The mandatory Requirements Class for this specification is:
 
 * "WIS2 Topic Hierarchy Core"

--- a/standard/sections/clause_7_normative_text.adoc
+++ b/standard/sections/clause_7_normative_text.adoc
@@ -2,11 +2,11 @@
 
 The WIS2 Topic Hierarchy provides a mechanism for users to subscribe to and receive data or metadata notifications. It is documented in discovery metadata records and leveraged by WIS2 brokers.
 
-=== Conformance Class Core
+=== Requirements Class Core
 
 ==== Overview
 
-This Core Conformance Class provides requirements for the definition and management of the WIS2 Topic Hierarchy.
+This Core Requirements Class provides requirements for the definition and management of the WIS2 Topic Hierarchy.
 
 include::../requirements/requirements_class_core.adoc[]
 


### PR DESCRIPTION
Editorial updates based on clarifications after reviewing OGC ModSpec.

- Requirements classes are put forth as 1..n requirements (per clauses in main document)
- Conformance classes are part of the ATS proper