### PR TITLE
Update clause_7_normative_text.adoc

### DIFF
--- a/standard/sections/clause_7_normative_text.adoc
+++ b/standard/sections/clause_7_normative_text.adoc
@@ -38,7 +38,7 @@ The table below provides an overview of the primary topic levels.
 
 |4
 |centre-id
-|Acronym as specified by member and endorsed by the PR of the country and WMO
+|Acronym proposed by member and endorsed by WMO Secretariat
 
 |5
 |notification-type


### PR DESCRIPTION
Proposed change on centre-id definition.
Being approved as a WIS Centre is a PR decision. When done, the centre-id doesn't need PR approval. However, it must be approved by WMO Sec.