### PR TITLE
Publication to codes registry and schemas.wmo.int via GitHub action

### DIFF
--- a/.github/workflows/publish-to-wmo-codes-testing.yml
+++ b/.github/workflows/publish-to-wmo-codes-testing.yml
@@ -29,5 +29,5 @@ jobs:
       - name: create TTL and publish to codes registry
         run: |
           python3 scripts/codelists2ttl.py
-          python3 scripts/upload_changes.py $WMO_CODES_TEST_USER_ID $WMO_CODES_TEST_API_KEY test wis/topic-hierarchy/centre-id/ --status stable
+          python3 scripts/upload_changes.py $WMO_CODES_TEST_USER_ID $WMO_CODES_TEST_API_KEY test wis/topic-hierarchy/centre-id/ --status experimental
       

--- a/.github/workflows/publish-to-wmo-codes-testing.yml
+++ b/.github/workflows/publish-to-wmo-codes-testing.yml
@@ -42,5 +42,4 @@ jobs:
         with:
           args: |
             --user $INFOMANIAK_USER:$INFOMANIAK_PW
-            --upload-file /tmp/wis2-topic-hierarchy-a.zip
-            ftps://egji.ftp.infomaniak.com/wth/a/wis2-topic-hierarchy-a_test.zip
+            --upload-file /tmp/wis2-topic-hierarchy-a.zip ftp://egji.ftp.infomaniak.com/wth/a/wis2-topic-hierarchy-a_test.zip

--- a/.github/workflows/publish-to-wmo-codes-testing.yml
+++ b/.github/workflows/publish-to-wmo-codes-testing.yml
@@ -36,6 +36,6 @@ jobs:
           pip3 install -r scripts/requirements.txt
       - name: create TTL and publish to codes registry
         run: |
-          python3 scripts/create_ttl.py
+          python3 scripts/codeslists2ttl.py
           python3 scripts/upload_changes.py $WMO_CODES_TEST_USER_ID $WMO_CODES_TEST_API_KEY test wis/topic-hierarchy/centre-id/ --status stable
       

--- a/.github/workflows/publish-to-wmo-codes-testing.yml
+++ b/.github/workflows/publish-to-wmo-codes-testing.yml
@@ -18,14 +18,11 @@ jobs:
     steps:
       - uses: actions/checkout@master
         with:
-          ref: code-registry-pub-test
+          ref: main
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: actions/checkout@master
-        with:
-          ref: main
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip

--- a/.github/workflows/publish-to-wmo-codes-testing.yml
+++ b/.github/workflows/publish-to-wmo-codes-testing.yml
@@ -37,9 +37,13 @@ jobs:
           python3 scripts/generate-bundle.py
           rm -rf /tmp/wis2-topic-hierarchy-a.zip
           zip /tmp/wis2-topic-hierarchy-a.zip topic-hierarchy/*.csv
+
       - name: upload bundle to Infomaniak
         uses: sozo-design/curl@v1.0.2
         with:
           args: |
             -T /tmp/wis2-topic-hierarchy-a.zip -u "$INFOMANIAK_USER:$INFOMANIAK_PW" ftps://egji.ftp.infomaniak.com/wth/a/wis2-topic-hierarchy-a_test.zip
+          run: |
+           ls -al /tmp/wth-bundle.zip .
+
       

--- a/.github/workflows/publish-to-wmo-codes-testing.yml
+++ b/.github/workflows/publish-to-wmo-codes-testing.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
         with:
-          ref: gh-pages
+          ref: code-registry-pub-test
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/publish-to-wmo-codes-testing.yml
+++ b/.github/workflows/publish-to-wmo-codes-testing.yml
@@ -37,5 +37,5 @@ jobs:
           python3 scripts/generate-bundle.py
           rm -rf /tmp/wis2-topic-hierarchy-a.zip
           zip /tmp/wis2-topic-hierarchy-a.zip topic-hierarchy/*.csv
-          curl -T /tmp/wis2-topic-hierarchy-a.zip -u "$INFOMANIAK_USER:$INFOMANIAK_PW" ftps://egji.ftp.infomaniak.com/wth/a/wis2-topic-hierarchy-a_test.zip
+          curl -s -T /tmp/wis2-topic-hierarchy-a.zip -u "$INFOMANIAK_USER:$INFOMANIAK_PW" ftps://egji.ftp.infomaniak.com/wth/a/wis2-topic-hierarchy-a_test.zip
       

--- a/.github/workflows/publish-to-wmo-codes-testing.yml
+++ b/.github/workflows/publish-to-wmo-codes-testing.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           python3 scripts/codelists2ttl.py
           python3 scripts/upload_changes.py $WMO_CODES_TEST_USER_ID $WMO_CODES_TEST_API_KEY test wis/topic-hierarchy/centre-id/ --status experimental
-      - name: create bundle   
+      - name: create bundle and upload to Infomaniak   
         run: |
           python3 scripts/generate-bundle.py
           rm -rf /tmp/wis2-topic-hierarchy-a.zip

--- a/.github/workflows/publish-to-wmo-codes-testing.yml
+++ b/.github/workflows/publish-to-wmo-codes-testing.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           python3 scripts/codelists2ttl.py
           python3 scripts/upload_changes.py $WMO_CODES_TEST_USER_ID $WMO_CODES_TEST_API_KEY test wis/topic-hierarchy/centre-id/ --status experimental
-      - name: create bundle 
+      - name: create bundle   
         run: |
           python3 scripts/generate-bundle.py
           rm -rf /tmp/wis2-topic-hierarchy-a.zip
@@ -42,3 +42,4 @@ jobs:
         with:
           args: |
             -T /tmp/wis2-topic-hierarchy-a.zip -u "$INFOMANIAK_USER:$INFOMANIAK_PW" ftps://egji.ftp.infomaniak.com/wth/a/wis2-topic-hierarchy-a_test.zip
+      

--- a/.github/workflows/publish-to-wmo-codes-testing.yml
+++ b/.github/workflows/publish-to-wmo-codes-testing.yml
@@ -37,5 +37,5 @@ jobs:
           python3 scripts/generate-bundle.py
           rm -rf /tmp/wis2-topic-hierarchy-a.zip
           zip /tmp/wis2-topic-hierarchy-a.zip topic-hierarchy/*.csv
-          curl -T /tmp/wis2-topic-hierarchy-a.zip ftps://$INFOMANIAK_USER:$INFOMANIAK_PW@egji.ftp.infomaniak.com/wth/a/wis2-topic-hierarchy-a_test.zip
+          curl -T /tmp/wis2-topic-hierarchy-a.zip -u "$INFOMANIAK_USER:$INFOMANIAK_PW" ftps://egji.ftp.infomaniak.com/wth/a/wis2-topic-hierarchy-a_test.zip
       

--- a/.github/workflows/publish-to-wmo-codes-testing.yml
+++ b/.github/workflows/publish-to-wmo-codes-testing.yml
@@ -3,6 +3,8 @@ name: Publish TTL files to WMO Codes Registry testing environment
 env:
   WMO_CODES_TEST_USER_ID: ${{ secrets.CODES_REGISTRY_API_USER_ID }}
   WMO_CODES_TEST_API_KEY: ${{ secrets.CODES_REGISTRY_API_SECRET_TEST }}
+  INFOMANIAK_USER: ${{ secrets.INFOMANIAK_SCHEMA_USER }}
+  INFOMANIAK_PW: ${{ secrets.INFOMANIAK_SCHEMA_PASSWORD }}
 
 on:
   push:
@@ -30,4 +32,15 @@ jobs:
         run: |
           python3 scripts/codelists2ttl.py
           python3 scripts/upload_changes.py $WMO_CODES_TEST_USER_ID $WMO_CODES_TEST_API_KEY test wis/topic-hierarchy/centre-id/ --status experimental
-      
+      - name: create bundle 
+        run: |
+          python3 scripts/generate-bundle.py
+          rm -rf /tmp/wis2-topic-hierarchy-a.zip
+          zip -j /tmp/wis2-topic-hierarchy-a.zip topic-hierarchy/*.csv
+      - name: upload bundle to Infomaniak
+        uses: sozo-design/curl@v1.0.2
+        with:
+          args: |
+            --user $INFOMANIAK_USER:$INFOMANIAK_PW
+            --upload-file /tmp/wis2-topic-hierarchy-a.zip
+            ftps://egji.ftp.infomaniak.com/wth/a/wis2-topic-hierarchy-a_test.zip

--- a/.github/workflows/publish-to-wmo-codes-testing.yml
+++ b/.github/workflows/publish-to-wmo-codes-testing.yml
@@ -37,13 +37,5 @@ jobs:
           python3 scripts/generate-bundle.py
           rm -rf /tmp/wis2-topic-hierarchy-a.zip
           zip /tmp/wis2-topic-hierarchy-a.zip topic-hierarchy/*.csv
-
-      - name: upload bundle to Infomaniak
-        uses: sozo-design/curl@v1.0.2
-        with:
-          args: |
-            -T /tmp/wis2-topic-hierarchy-a.zip -u "$INFOMANIAK_USER:$INFOMANIAK_PW" ftps://egji.ftp.infomaniak.com/wth/a/wis2-topic-hierarchy-a_test.zip
-          run: |
-           ls -al /tmp/wth-bundle.zip .
-
+          curl -T /tmp/wis2-topic-hierarchy-a.zip -u "$INFOMANIAK_USER:$INFOMANIAK_PW" ftps://egji.ftp.infomaniak.com/wth/a/wis2-topic-hierarchy-a_test.zip
       

--- a/.github/workflows/publish-to-wmo-codes-testing.yml
+++ b/.github/workflows/publish-to-wmo-codes-testing.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           python3 scripts/generate-bundle.py
           rm -rf /tmp/wis2-topic-hierarchy-a.zip
-          zip -j /tmp/wis2-topic-hierarchy-a.zip topic-hierarchy/*.csv
+          zip /tmp/wis2-topic-hierarchy-a.zip topic-hierarchy/*.csv
       - name: upload bundle to Infomaniak
         uses: sozo-design/curl@v1.0.2
         with:

--- a/.github/workflows/publish-to-wmo-codes-testing.yml
+++ b/.github/workflows/publish-to-wmo-codes-testing.yml
@@ -23,10 +23,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Copy TTL files
-        run: |
-          mkdir /tmp/wis
-          cp -rp wis/ /tmp/
       - uses: actions/checkout@master
         with:
           ref: main

--- a/.github/workflows/publish-to-wmo-codes-testing.yml
+++ b/.github/workflows/publish-to-wmo-codes-testing.yml
@@ -37,5 +37,5 @@ jobs:
           python3 scripts/generate-bundle.py
           rm -rf /tmp/wis2-topic-hierarchy-a.zip
           zip /tmp/wis2-topic-hierarchy-a.zip topic-hierarchy/*.csv
-          curl -T /tmp/wis2-topic-hierarchy-a.zip -u "$INFOMANIAK_USER:$INFOMANIAK_PW" ftps://egji.ftp.infomaniak.com/wth/a/wis2-topic-hierarchy-a_test.zip
+          curl -T /tmp/wis2-topic-hierarchy-a.zip -u "$INFOMANIAK_USER:$INFOMANIAK_PW" ftp://egji.ftp.infomaniak.com/wis2-topic-hierarchy-a_test.zip
       

--- a/.github/workflows/publish-to-wmo-codes-testing.yml
+++ b/.github/workflows/publish-to-wmo-codes-testing.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           python3 scripts/codelists2ttl.py
           python3 scripts/upload_changes.py $WMO_CODES_TEST_USER_ID $WMO_CODES_TEST_API_KEY test wis/topic-hierarchy/centre-id/ --status experimental
-      - name: create bundle and upload to Infomaniak   
+      - name: create bundle and upload to Infomaniak via ftp   
         run: |
           python3 scripts/generate-bundle.py
           rm -rf /tmp/wis2-topic-hierarchy-a.zip

--- a/.github/workflows/publish-to-wmo-codes-testing.yml
+++ b/.github/workflows/publish-to-wmo-codes-testing.yml
@@ -8,6 +8,9 @@ on:
   push:
     branches:
       - code-registry-pub-test
+      paths:
+      - '**.yml'
+      - 'topic-hierarchy/**.csv'
 
 jobs:
   main:
@@ -17,8 +20,6 @@ jobs:
         python-version: ['3.10']
     steps:
       - uses: actions/checkout@master
-        with:
-          ref: main
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -29,6 +30,6 @@ jobs:
           pip3 install -r scripts/requirements.txt
       - name: create TTL and publish to codes registry
         run: |
-          python3 scripts/codeslists2ttl.py
+          python3 scripts/codelists2ttl.py
           python3 scripts/upload_changes.py $WMO_CODES_TEST_USER_ID $WMO_CODES_TEST_API_KEY test wis/topic-hierarchy/centre-id/ --status stable
       

--- a/.github/workflows/publish-to-wmo-codes-testing.yml
+++ b/.github/workflows/publish-to-wmo-codes-testing.yml
@@ -1,15 +1,13 @@
 name: Publish TTL files to WMO Codes Registry testing environment
 
 env:
-  WMO_CODES_TEST_USER_ID: ${{ secrets.WMO_CODES_TEST_USER_ID }}
-  WMO_CODES_TEST_API_KEY: ${{ secrets.WMO_CODES_TEST_API_KEY }}
+  WMO_CODES_TEST_USER_ID: ${{ secrets.CODES_REGISTRY_API_USER_ID }}
+  WMO_CODES_TEST_API_KEY: ${{ secrets.CODES_REGISTRY_API_SECRET_TEST }}
 
 on:
   push:
     branches:
-      - gh-pages
-    paths:
-      - 'wis/**.ttl'
+      - code-registry-pub-test
 
 jobs:
   main:
@@ -36,6 +34,8 @@ jobs:
         run: |
           python3 -m pip install --upgrade pip
           pip3 install -r scripts/requirements.txt
-     # - name: update gh-pages branch and publish
-     #   run: |
-     #     python3 scripts/upload_changes.py {WMO_CODES_TEST_USER_ID} {WMO_CODES_TEST_API_KEY} test /tmp/wis --status experimental
+      - name: create TTL and publish to codes registry
+        run: |
+          python3 scripts/create_ttl.py
+          python3 scripts/upload_changes.py $WMO_CODES_TEST_USER_ID $WMO_CODES_TEST_API_KEY test wis/topic-hierarchy/centre-id/ --status stable
+      

--- a/.github/workflows/publish-to-wmo-codes-testing.yml
+++ b/.github/workflows/publish-to-wmo-codes-testing.yml
@@ -8,9 +8,7 @@ on:
   push:
     branches:
       - code-registry-pub-test
-      paths:
-      - '**.yml'
-      - 'topic-hierarchy/**.csv'
+
 
 jobs:
   main:

--- a/.github/workflows/publish-to-wmo-codes-testing.yml
+++ b/.github/workflows/publish-to-wmo-codes-testing.yml
@@ -37,5 +37,5 @@ jobs:
           python3 scripts/generate-bundle.py
           rm -rf /tmp/wis2-topic-hierarchy-a.zip
           zip /tmp/wis2-topic-hierarchy-a.zip topic-hierarchy/*.csv
-          curl -s -T /tmp/wis2-topic-hierarchy-a.zip -u "$INFOMANIAK_USER:$INFOMANIAK_PW" ftps://egji.ftp.infomaniak.com/wth/a/wis2-topic-hierarchy-a_test.zip
+          curl -T /tmp/wis2-topic-hierarchy-a.zip ftps://$INFOMANIAK_USER:$INFOMANIAK_PW@egji.ftp.infomaniak.com/wth/a/wis2-topic-hierarchy-a_test.zip
       

--- a/.github/workflows/publish-to-wmo-codes-testing.yml
+++ b/.github/workflows/publish-to-wmo-codes-testing.yml
@@ -41,5 +41,4 @@ jobs:
         uses: sozo-design/curl@v1.0.2
         with:
           args: |
-            --user $INFOMANIAK_USER:$INFOMANIAK_PW
-            --upload-file /tmp/wis2-topic-hierarchy-a.zip ftp://egji.ftp.infomaniak.com/wth/a/wis2-topic-hierarchy-a_test.zip
+            -T /tmp/wis2-topic-hierarchy-a.zip -u "$INFOMANIAK_USER:$INFOMANIAK_PW" ftps://egji.ftp.infomaniak.com/wth/a/wis2-topic-hierarchy-a_test.zip

--- a/topic-hierarchy/centre-id.csv
+++ b/topic-hierarchy/centre-id.csv
@@ -1,4 +1,5 @@
 Name,Description,Source,Status
+a-test-4,test 4 on 11 July,,Operational
 a-test-3,test 3 on 10 July,,Operational
 a-test-1,test 1 on 3 July,,Operational
 a-test-2,test 2 on 3 July,,Inactive

--- a/topic-hierarchy/centre-id.csv
+++ b/topic-hierarchy/centre-id.csv
@@ -1,4 +1,5 @@
 Name,Description,Source,Status
+a-test-6,test 5 on 15 July,,Operational
 a-test-5,test 5 on 15 July,,Operational
 a-test-4,test 4 on 11 July,,Operational
 a-test-3,test 3 on 10 July,,Operational

--- a/topic-hierarchy/centre-id.csv
+++ b/topic-hierarchy/centre-id.csv
@@ -1,4 +1,5 @@
 Name,Description,Source,Status
+a-test-3,test 3 on 10 July,,Operational
 a-test-1,test 1 on 3 July,,Operational
 a-test-2,test 2 on 3 July,,Inactive
 ag-antiguamet,Antigua and Barbuda Meteorological Services,,Operational

--- a/topic-hierarchy/centre-id.csv
+++ b/topic-hierarchy/centre-id.csv
@@ -1,4 +1,5 @@
 Name,Description,Source,Status
+a-test-5,test 5 on 15 July,,Operational
 a-test-4,test 4 on 11 July,,Operational
 a-test-3,test 3 on 10 July,,Operational
 a-test-1,test 1 on 3 July,,Operational

--- a/wis2-topic-hierarchy.code-workspace
+++ b/wis2-topic-hierarchy.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "."
+		},
+		{
+			"name": "wis2-topic-hierarchy",
+			"path": "wis2-topic-hierarchy"
+		}
+	],
+	"settings": {}
+}


### PR DESCRIPTION
This GitHub action builds the TTL files and bundles, and uploads them to the codes-registry and schemas.wmo.int. 
Credentials are created in the codes registry and Infomaniak and stored as GitHub secrets. 
In this code the bundle filename is postfixed "_test" and the test version of the codes registry is used.